### PR TITLE
Upgraded the library to require at least PHP8.1 and illuminate/queue 10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .php_cs.cache
 composer.lock
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,21 @@
         {
             "name": "Dario Govergun",
             "email": "dgovergun@digbang.com"
+        },
+        {
+            "name": "DIJ Digital",
+            "email": "support@dij.digital"
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0.2",
-        "illuminate/queue": "^8.0 || ^9.0",
-        "laravel-doctrine/orm": "^1.7"
+        "php": "^8.1",
+        "illuminate/queue": "^10.0",
+        "laravel-doctrine/orm": "^2.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^8.5 || ^9.5",
-        "friendsofphp/php-cs-fixer": "^3.6"
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^10.0",
+        "friendsofphp/php-cs-fixer": "^3.40"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +33,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "test\\Digbang\\SafeQueue\\": "tests/"
+            "Digbang\\SafeQueue\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <testsuites>
     <testsuite name="Full Test Suite">
       <directory>./tests/</directory>
@@ -12,4 +8,9 @@
   </testsuites>
   <php>
     </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -31,7 +31,7 @@ class WorkCommand extends IlluminateWorkCommand
         parent::__construct($worker, $cache);
     }
 
-    public function renameCommandInSignature($commandName)
+    public function renameCommandInSignature($commandName): void
     {
         if ($commandName) {
             /**

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -8,7 +8,7 @@ use Digbang\SafeQueue\Worker;
 
 class WorkCommand extends IlluminateWorkCommand
 {
-    const SIGNATURE_REGEX_PATTERN = '/([\w:-]+)(?=\s|\{)/i';
+    public const SIGNATURE_REGEX_PATTERN = '/([\w:-]+)(?=\s|\{)/i';
 
     /**
      * The console command description.

--- a/src/DoctrineQueueProvider.php
+++ b/src/DoctrineQueueProvider.php
@@ -2,24 +2,22 @@
 
 namespace Digbang\SafeQueue;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Digbang\SafeQueue\Console\WorkCommand;
 use Illuminate\Contracts\Cache\Repository as Cache;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 
 /**
  * @codeCoverageIgnore
  */
-class DoctrineQueueProvider extends ServiceProvider
+class DoctrineQueueProvider extends ServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
-
     /**
      * Register the service provider.
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         if (!$this->isLumen()) {
             $this->publishes([
@@ -35,7 +33,7 @@ class DoctrineQueueProvider extends ServiceProvider
         $this->registerWorker();
     }
 
-    public function boot()
+    public function boot(): void
     {
         $this->commands('command.safeQueue.work');
     }
@@ -43,7 +41,7 @@ class DoctrineQueueProvider extends ServiceProvider
     /**
      * @return void
      */
-    protected function registerWorker()
+    protected function registerWorker(): void
     {
         $this->registerWorkCommand();
 
@@ -65,7 +63,7 @@ class DoctrineQueueProvider extends ServiceProvider
     /**
      * @return void
      */
-    protected function registerWorkCommand()
+    protected function registerWorkCommand(): void
     {
         $this->app->singleton('command.safeQueue.work', function ($app) {
             return new WorkCommand(
@@ -81,7 +79,7 @@ class DoctrineQueueProvider extends ServiceProvider
      *
      * @return array
      */
-    public function provides()
+    public function provides(): array
     {
         return [
             'safeQueue.worker',
@@ -92,8 +90,8 @@ class DoctrineQueueProvider extends ServiceProvider
     /**
      * @return bool
      */
-    protected function isLumen()
+    protected function isLumen(): bool
     {
-        return strpos($this->app->version(), 'Lumen') !== false;
+        return str_contains($this->app->version(), 'Lumen');
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -2,24 +2,17 @@
 
 namespace Digbang\SafeQueue;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker as IlluminateWorker;
-use Illuminate\Queue\WorkerOptions;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 
 class Worker extends IlluminateWorker
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $managerRegistry;
+    protected ManagerRegistry $managerRegistry;
 
     /**
      * Worker constructor.
@@ -28,7 +21,7 @@ class Worker extends IlluminateWorker
      * @param Dispatcher $events
      * @param ManagerRegistry $managerRegistry
      * @param ExceptionHandler $exceptions
-     * @param \callable $isDownForMaintenance
+     * @param callable $isDownForMaintenance
      */
     public function __construct(
         QueueManager $manager,
@@ -62,10 +55,8 @@ class Worker extends IlluminateWorker
             $this->assertGoodDatabaseConnection();
         } catch (EntityManagerClosedException $e) {
             $exception = $e;
-        } catch (Exception $e) {
+        } catch (Exception|Throwable $e) {
             $exception = new QueueSetupException("Error in queue setup while getting next job", 0, $e);
-        } catch (Throwable $e) {
-            $exception = new QueueSetupException("Error in queue setup while getting next job", 0, new FatalThrowableError($e));
         }
 
         if ($exception) {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -76,7 +76,7 @@ class Worker extends IlluminateWorker
     {
         foreach ($this->managerRegistry->getManagers() as $entityManager) {
             if (!$entityManager->isOpen()) {
-                throw new EntityManagerClosedException;
+                throw new EntityManagerClosedException();
             }
         }
     }

--- a/tests/Console/WorkCommandTest.php
+++ b/tests/Console/WorkCommandTest.php
@@ -1,7 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
-namespace tests\Digbang\SafeQueue\Console;
+namespace Digbang\SafeQueue\Tests\Console;
 
 use Mockery as m;
 use ReflectionClass;
@@ -12,6 +13,8 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 
 class WorkCommandTest extends TestCase
 {
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @var Worker|m\MockInterface
      */

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -1,7 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
-namespace tests\Digbang\SafeQueue;
+namespace Digbang\SafeQueue\Tests;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
@@ -21,6 +22,8 @@ use PHPUnit\Framework\TestCase;
 
 class WorkerTest extends TestCase
 {
+    use m\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     /**
      * @var QueueManager|m\MockInterface
      */
@@ -96,12 +99,7 @@ class WorkerTest extends TestCase
         $this->entityManager->shouldReceive('getConnection')->andReturn($this->dbConnection);
     }
 
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
-    protected function prepareToRunJob($job)
+    protected function prepareToRunJob($job): void
     {
         if ($job instanceof Job) {
             $jobs = [$job];
@@ -114,6 +112,7 @@ class WorkerTest extends TestCase
         $this->queueManager->shouldReceive('getName')->andReturn('test');
 
         $this->queue->shouldReceive('pop')->andReturn(...$jobs);
+        $this->queue->shouldReceive('getConnectionName')->andReturn('test');
     }
 
     public function testExtendsLaravelWorker()
@@ -123,8 +122,7 @@ class WorkerTest extends TestCase
 
     public function testChecksEmState()
     {
-        $job = m::mock(Job::class);
-        $job->shouldReceive('fire')->once();
+        $job = m::spy(Job::class);
         $job->shouldIgnoreMissing();
 
         $this->prepareToRunJob($job);
@@ -143,11 +141,12 @@ class WorkerTest extends TestCase
         $this->managerRegistry->shouldReceive('getManagers')->andReturn(array($this->entityManager));
 
         $this->worker->runNextJob('connection', 'queue', $this->options);
+
+        $job->shouldHaveReceived('fire')->once();
     }
 
     public function testMultipleEntityManagers() {
-        $job = m::mock(Job::class);
-        $job->shouldReceive('fire')->once();
+        $job = m::spy(Job::class);
         $job->shouldIgnoreMissing();
 
         $this->prepareToRunJob($job);
@@ -172,5 +171,7 @@ class WorkerTest extends TestCase
         $this->managerRegistry->shouldReceive('getManagers')->andReturn(array($this->entityManager, $secondManager));
 
         $this->worker->runNextJob('connection', 'queue', $this->options);
+
+        $job->shouldHaveReceived('fire')->once();
     }
 }

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -84,7 +84,7 @@ class WorkerTest extends TestCase
         $this->cache         = m::mock(Repository::class);
         $this->exceptions    = m::mock(Handler::class);
         $this->managerRegistry = m::mock(ManagerRegistry::class);
-        $isDownForMaintenance= function () {
+        $isDownForMaintenance = function () {
             return false;
         };
 
@@ -145,7 +145,8 @@ class WorkerTest extends TestCase
         $job->shouldHaveReceived('fire')->once();
     }
 
-    public function testMultipleEntityManagers() {
+    public function testMultipleEntityManagers()
+    {
         $job = m::spy(Job::class);
         $job->shouldIgnoreMissing();
 


### PR DESCRIPTION
- Upgraded the laravel-doctrine/orm package to version 2.0
- Require phpunit version 10 and migrated the phpunit.xml.dist to the newest schema
- Merged the Throwable catch branch with the Exception catch branch in the Worker.php as it used an exception class that is no longer available
- Added the MockeryPHPUnitIntegration trait to the testcases to allow Mockery to influence the expectation count
- Changed the namespace of the test cases to Digbang\SafeQueue\Tests
- DoctrineQueueProvider now implements DeferrableProvider instead of using the $defer property
- Added some return type (non-exhaustive)