### PR TITLE
alternative method for removed ping

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -101,7 +101,7 @@ class Worker extends IlluminateWorker
         foreach ($this->managerRegistry->getManagers() as $entityManager) {
             $connection = $entityManager->getConnection();
 
-            if ($connection->ping() === false) {
+            if (!$connection->isConnected()) {
                 $connection->close();
                 $connection->connect();
             }


### PR DESCRIPTION
Ping was deprecated and now removed. More info here: https://github.com/doctrine/dbal/pull/4119
isConnected seems a good alternative